### PR TITLE
Add new permissions: Limit deleting own messages to last post

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Permission to limit how old a post/thread can be and still be deleted. XenForo doesn't handle deleting posts from super-long threads well
 
-Introduces 1 new permissions:
+Introduces 2 new permissions:
 
 - Time limit on deleting own messages (minutes)
-
+- Limit deleting own messages to last post in tread

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Permission to limit how old a post/thread can be and still be deleted. XenForo d
 Introduces 2 new permissions:
 
 - Time limit on deleting own messages (minutes)
-- Limit deleting own messages to last post in tread
+- Limit deleting own messages to last post in thread

--- a/upload/src/addons/SV/PostDeleteTimeLimit/XF/Entity/Post.php
+++ b/upload/src/addons/SV/PostDeleteTimeLimit/XF/Entity/Post.php
@@ -29,6 +29,16 @@ class Post extends XFCP_Post
             return false;
         }
 
+		$ownLastOnly = $visitor->hasNodePermission($nodeId, 'deleteOwnLastPostOnly');
+		
+        if (  $ownLastOnly && !$this->isLastPost() )
+        {
+			
+            $error = \XF::phraseDeferred('permission.message_delete_another_post', ['minutes' => $deleteLimit]);
+
+            return false;
+        }
+        
         return true;
     }
 }

--- a/upload/src/addons/SV/PostDeleteTimeLimit/XF/Entity/Post.php
+++ b/upload/src/addons/SV/PostDeleteTimeLimit/XF/Entity/Post.php
@@ -34,7 +34,7 @@ class Post extends XFCP_Post
         if (  $ownLastOnly && !$this->isLastPost() )
         {
 			
-            $error = \XF::phraseDeferred('permission.message_delete_another_post', ['minutes' => $deleteLimit]);
+            $error = \XF::phraseDeferred('permission.message_delete_another_post');
 
             return false;
         }

--- a/upload/src/addons/SV/PostDeleteTimeLimit/XF/Entity/Thread.php
+++ b/upload/src/addons/SV/PostDeleteTimeLimit/XF/Entity/Thread.php
@@ -31,6 +31,15 @@ class Thread extends XFCP_Thread
 
             return false;
         }
+		
+		$ownLastOnly = $visitor->hasNodePermission($nodeId, 'deleteOwnLastPostOnly');
+		
+        if ( $ownLastOnly && $this->reply_count > 0 )
+        {
+            $error = \XF::phraseDeferred('permission.message_delete_another_post');
+
+            return false;
+        }
 
         return true;
     }

--- a/upload/src/addons/SV/PostDeleteTimeLimit/_output/permissions/forum-deleteOwnLastPostOnly.json
+++ b/upload/src/addons/SV/PostDeleteTimeLimit/_output/permissions/forum-deleteOwnLastPostOnly.json
@@ -1,0 +1,6 @@
+{
+    "permission_type": "flag",
+    "interface_group_id": "forumPermissions",
+    "display_order": 21,
+    "depend_permission_id": ""
+}

--- a/upload/src/addons/SV/PostDeleteTimeLimit/_output/phrases/permission.forum_deleteOwnLastPostOnly.txt
+++ b/upload/src/addons/SV/PostDeleteTimeLimit/_output/phrases/permission.forum_deleteOwnLastPostOnly.txt
@@ -1,0 +1,1 @@
+Limit deleting own posts to last post

--- a/upload/src/addons/SV/PostDeleteTimeLimit/_output/phrases/permission.message_delete_another_post.txt
+++ b/upload/src/addons/SV/PostDeleteTimeLimit/_output/phrases/permission.message_delete_another_post.txt
@@ -1,0 +1,1 @@
+The message could not be removed because new messages were posted

--- a/upload/src/addons/SV/PostDeleteTimeLimit/addon.json
+++ b/upload/src/addons/SV/PostDeleteTimeLimit/addon.json
@@ -3,7 +3,7 @@
     "title": "Post Delete Time Limit",
     "description": "Prevent old posts from being deleted",
     "version_id": 2001000,
-    "version_string": "2.1.0",
+    "version_string": "2.2.0",
     "dev" : "Xon",
     "dev_url": "https://atelieraphelion.com/",
     "faq_url": "",


### PR DESCRIPTION
Hey,
I had to add a new permission that a user would not be able to delete messages if someone else sent a message after them.
I thought you might want to add this to the add-on.

Thank you for the add-on.
Uriel